### PR TITLE
fix: Add tzdata to Dockerfile for timezone support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /duder
 # Final stage - minimal Alpine image
 FROM alpine:latest
 
-# Add CA certs for HTTPS requests
-RUN apk --no-cache add ca-certificates
+# Add CA certs for HTTPS requests and timezone data for scheduling
+RUN apk --no-cache add ca-certificates tzdata
 
 COPY --from=builder /duder /duder
 


### PR DESCRIPTION
The Friday video scheduler uses `time.LoadLocation("America/Los_Angeles")` which requires timezone data. Alpine Linux doesn't include this by default, causing the scheduler to fail with:

```
Failed to load timezone: unknown time zone America/Los_Angeles
```

**Fix:** Add `tzdata` to the `apk install` in the Dockerfile.